### PR TITLE
init: Adjust rc script include order

### DIFF
--- a/rootdir/init.extension.rc
+++ b/rootdir/init.extension.rc
@@ -11,3 +11,6 @@ import /vendor/etc/init/hw/init.haptic.rc
 import /vendor/etc/init/hw/init.fingerprint.rc
 import /vendor/etc/init/hw/init.light.rc
 import /vendor/etc/init/hw/init.led.rc
+
+# Include init.flowertome.rc
+import /vendor/etc/init/hw/init.flowertome.rc

--- a/rootdir/init.target.rc
+++ b/rootdir/init.target.rc
@@ -30,9 +30,6 @@
 # Import init.nubia.rc
 import /vendor/etc/init/hw/init.extension.rc
 
-# Include init.flowertome.rc
-import /vendor/etc/init/hw/init.flowertome.rc
-
 on early-init
     exec u:r:vendor_modprobe:s0 -- /vendor/bin/modprobe -a -d /vendor/lib/modules audio_wglink audio_q6_pdr audio_q6_notifier audio_apr audio_adsp_loader audio_q6 audio_native audio_usf audio_pinctrl_wcd audio_swr audio_platform audio_hdmi audio_wcd_spi audio_stub audio_wcd_core audio_wsa881x audio_tfa9894 audio_wcd9360 audio_hdmi audio_machine_msmnile
     write /proc/sys/kernel/sched_boost 1


### PR DESCRIPTION
I think your new rc script should be included in init.extension.rc